### PR TITLE
Subscription URL changes per graph.cool instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const networkInterface = createNetworkInterface({
   uri: 'https://api.graph.cool/simple/v1/__PROJECT_ID__'
 })
 
-const wsClient = new SubscriptionClient('wss://subscriptions.graph.cool/v1/__PROJECT_ID__', {
+const wsClient = new SubscriptionClient('__SUBSCRIPTION_URL__', {
   reconnect: true,
   connectionParams: {
     authToken: localStorage.getItem(GC_AUTH_TOKEN),


### PR DESCRIPTION
The entire subscription URL needs to be entered as it is not always the same.

For example my one started with `wss://subscriptions.us-west-2.graph.cool/v1/`

No errors get thrown, but the subscriptions don't work.