### PR TITLE
Updated/harcode subscriptions-transport-ws to 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react-apollo": "^1.4.2",
     "react-dom": "^15.6.1",
     "react-router-dom": "^4.1.1",
-    "subscriptions-transport-ws": "^0.8.2"
+    "subscriptions-transport-ws": "0.8.2"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Currently the latest version of `subscriptions-transport-ws` breaks/removes `addGraphQLSubscriptions` function. This should resolve #9 , once the Apollo 2 version is figure out this will probably not be needed. 