### PR TITLE
added typename to allow updateQuery with websocket

### DIFF
--- a/src/components/LinkList.js
+++ b/src/components/LinkList.js
@@ -122,6 +122,7 @@ class LinkList extends Component {
         const result = {
           ...previous,
           feed: {
+            __typename: previous.feed.__typename,
             links: newAllLinks,
           },
         }


### PR DESCRIPTION
If following the tutorial exactly, step 8 ([subscriptions](https://www.howtographql.com/react-apollo/8-subscriptions/)) will fail due to this error:

![image](https://user-images.githubusercontent.com/22530815/40072422-6c6a6566-5839-11e8-8593-03800a3b0a14.png)

After some [searching](https://github.com/apollographql/apollo-client/issues/1733#issuecomment-303626084), I found that adding typename manually fixes the error.
