### PR TITLE
Changes feed to use the count prop of the object returned by aggregate()

### DIFF
--- a/server/src/resolvers/Query.js
+++ b/server/src/resolvers/Query.js
@@ -1,5 +1,5 @@
 async function feed(parent, args, context) {
-  const count = await context.prisma
+  const { count } = await context.prisma
     .linksConnection({
       where: {
         OR: [
@@ -9,7 +9,6 @@ async function feed(parent, args, context) {
       },
     })
     .aggregate()
-    .count()
   const links = await context.prisma.links({
     where: {
       OR: [


### PR DESCRIPTION
Fixes  https://github.com/howtographql/howtographql/issues/869

The type definition shows that this method returns an AggregateLink,
which has a single prop `count`. Change uses that property rather than
trying to call the method count() on the returned object.

```
export interface AggregateLink {
  count: Int;
}
```

Here's the callstack for the error I was seeing prior to the change.

```
Error: Field 'count' of type 'Int' must not have a sub selection. (line 4, column 7):
      count {
      ^
    at BatchedGraphQLClient.<anonymous> (/Users/marc/Code/marcdel/hackernews-react-apollo/server/node_modules/http-link-dataloader/dist/src/BatchedGraphQLClient.js:77:35)
    at step (/Users/marc/Code/marcdel/hackernews-react-apollo/server/node_modules/http-link-dataloader/dist/src/BatchedGraphQLClient.js:40:23)
    at Object.next (/Users/marc/Code/marcdel/hackernews-react-apollo/server/node_modules/http-link-dataloader/dist/src/BatchedGraphQLClient.js:21:53)
    at fulfilled (/Users/marc/Code/marcdel/hackernews-react-apollo/server/node_modules/http-link-dataloader/dist/src/BatchedGraphQLClient.js:12:58)
    at process.internalTickCallback (internal/process/next_tick.js:77:7)
```